### PR TITLE
SOE-1594: Removed display: inline css, added deprecate_image_credits()

### DIFF
--- a/css/stanford_jumpstart_engineering.css
+++ b/css/stanford_jumpstart_engineering.css
@@ -88,13 +88,3 @@
 
 /* NEWS */
 
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption .field-name-field-s-image-caption,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-name-field-s-image-credits,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .field-items,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .field-item,
-.node-type-stanford-news-item .field-name-field-s-image-info .content p {
-  display: inline;
-}
-

--- a/modules/stanford_jse_dept/css/stanford_jse_dept_styles.css
+++ b/modules/stanford_jse_dept/css/stanford_jse_dept_styles.css
@@ -152,19 +152,6 @@ ul.pager li.pager-current {
     border-top: 1px solid #d6d6d6;
 }
 
-/* NEWS */
-
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-caption-style.field-group-div.caption .field-name-field-s-image-caption,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .group-s-credits-style.field-group-div.credits .field-name-field-s-image-credits,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .field-items,
-.node-type-stanford-news-item .field-name-field-s-image-info .content .field-item,
-.node-type-stanford-news-item .field-name-field-s-image-info .content p {
-    display: inline;
-}
-
-
 /* CALENDAR */
 
 .view-stanford-events-calendar .view-header .date-nav-wrapper {

--- a/modules/stanford_jse_dept/stanford_jse_dept.info
+++ b/modules/stanford_jse_dept/stanford_jse_dept.info
@@ -5,6 +5,7 @@ package = Stanford
 version = 7.x-5.3-dev
 project = stanford_jumpstart_engineering
 dependencies[] = stanford_jse_related_content
+dependencies[] = stanford_news_extras
 stylesheets[all][] = css/stanford_jse_dept_related_content.css
 ; scripts[] = js/stanford_module.js
 project status url = https://github.com/SU-SWS/stanford_jumpstart_engineering

--- a/modules/stanford_jse_dept/stanford_jse_dept.module
+++ b/modules/stanford_jse_dept/stanford_jse_dept.module
@@ -8,9 +8,6 @@
  *
  */
 
-
-
-
 /**
  * Implements hook_form_alter().
  */

--- a/modules/stanford_jse_dept/stanford_jse_dept.module
+++ b/modules/stanford_jse_dept/stanford_jse_dept.module
@@ -25,6 +25,12 @@ function stanford_jse_dept_form_alter(&$form, &$form_state, $form_id) {
     $form['design_container']['styles']['#options']['styles-jse-dept'] =
       '<span class="design-style ds-jse-dept">' . t('SoE Department') . '</span>';
   }
+  elseif ($form_id = 'views_exposed_form') {
+    if($form['#id'] === 'views-exposed-form-stanford-news-with-teaser-page-1') {
+      unset($form['field_s_news_categories_tid']);
+      unset($form['#info']['filter-field_s_news_categories_tid']);
+    }
+  }
 }
 
 /**
@@ -98,3 +104,4 @@ user/*/edit";
     default:
   }
 }
+

--- a/stanford_jumpstart_engineering.module
+++ b/stanford_jumpstart_engineering.module
@@ -17,4 +17,18 @@ function stanford_jumpstart_engineering_form_alter(&$form, &$form_state, $form_i
     unset($form['design_container']['styles']['#options']['styles-bright']);
     unset($form['design_container']['styles']['#options']['styles-vivid']);
   }
+
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter() for stanford_news_item_node_form.
+ */
+function stanford_jumpstart_engineering_form_stanford_news_item_node_form_alter(
+  &$form,
+  &$form_state,
+  $form_id) {
+
+  // Handle deprecation of image credits.
+  stanford_news_extras_deprecate_image_credits($form, $form_id);
+}
+

--- a/stanford_jumpstart_engineering.module
+++ b/stanford_jumpstart_engineering.module
@@ -29,6 +29,8 @@ function stanford_jumpstart_engineering_form_stanford_news_item_node_form_alter(
   $form_id) {
 
   // Handle deprecation of image credits.
-  stanford_news_extras_deprecate_image_credits($form, $form_id);
+  if (function_exists('stanford_news_extras_deprecate_image_credits')) {
+    stanford_news_extras_deprecate_image_credits($form, $form_id);
+  }
 }
 


### PR DESCRIPTION
# Purpose
This PR works in conjunction with and depends on 
https://github.com/SU-SWS/stanford_news/pull/46

Since we want to combine caption and credits into a single field,
it works to deprecate the credits field on the news item for news extras. 
If text is in the credits field, that field is displayed. If there's no text then the credits field is not displayed. As well, it changes the title and description for both the caption and credits fields.

# Status
- Ready

# Needed By (Date)
-  David says it's GTG

# Urgency
- Client is watching this, and it is for the live SoE site.

# Steps to Test

1. On an existing JSE PICAL dev site put credits into an image field on a news item
2. Pull this onto the site, flush cache
3. Check if the title and help text has changed for both the caption and credits field from  Step 1
4. Edit the news item and remove text from the credits field and save
5. Edit the news item and verify that the credits field does not appear.
6. Create a new news item. Verify that credits field does not appear.

Repeat for an existing JSE Department dev site
Also, on Department sites, verify that the "Filter by category" filter on News has been removed.

# Affected Projects or Products
- This PR is dependent upon the news PR:
https://github.com/SU-SWS/stanford_news/pull/46
- Does this PR impact any particular projects, products, or modules?

# Associated Issues
-  https://stanfordits.atlassian.net/browse/SOE-1594
- https://github.com/SU-SWS/stanford_news/pull/46
- https://github.com/SU-SOE/stanford_soe_helper/pull/16
